### PR TITLE
chore: Update "ubication" column in "Post" table

### DIFF
--- a/prisma/migrations/20240519144857_/migration.sql
+++ b/prisma/migrations/20240519144857_/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - The `ubication` column on the `Post` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+
+*/
+-- AlterTable
+ALTER TABLE "Post" DROP COLUMN "ubication",
+ADD COLUMN     "ubication" DOUBLE PRECISION[];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,7 +44,7 @@ model Post {
   published   Boolean
   price       Float
   onSale      Boolean
-  ubication   String[]
+  ubication   String
   frontImage  String
   images      String[]
   type        String


### PR DESCRIPTION
The "ubication" column in the "Post" table has been modified to use the data type DOUBLE PRECISION[]. This change was made to improve the storage and retrieval of location data for posts.