### PR TITLE
feat: Remove unused code in Post service

### DIFF
--- a/services/post.services.js
+++ b/services/post.services.js
@@ -106,8 +106,6 @@ class Post {
       if (pool != undefined && pool != "") where.pool = JSON.parse(pool);
       if (pets != undefined && pets != "") where.pets = JSON.parse(pets);
 
-      if (idSeller != undefined && idSeller != "") where.sellerId = idSeller;
-
       console.log(where)
 
       const prisma = new PrismaClient();


### PR DESCRIPTION
The unused code related to the `idSeller` parameter in the `Post` service has been removed. This improves the codebase by eliminating unnecessary variables and simplifying the logic.